### PR TITLE
Fix sw.js overwrite

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -81,7 +81,7 @@ function addOneSignal (oneSignalOptions) {
   if (!this.options.workbox) {
     this.options.workbox = {}
   }
-  this.options.workbox.swURL = 'OneSignalSDKWorker.js'
+  this.options.pwa.workbox.swURL = 'OneSignalSDKWorker.js'
 
   // Provide OneSignalSDKWorker.js and OneSignalSDKUpdaterWorker.js
   const makeSW = (name, scripts) => {

--- a/lib/module.js
+++ b/lib/module.js
@@ -90,7 +90,7 @@ function addOneSignal (oneSignalOptions) {
   }
 
   makeSW('OneSignalSDKWorker.js', [].concat(options.importScripts || []).concat(options.OneSignalSDK))
-  makeSW('OneSignalSDKUpdaterWorker.js', [options.OneSignalSDK])
+  makeSW('OneSignalSDKUpdaterWorker.js', [].concat(options.importScripts || []).concat(options.OneSignalSDK))
 
   // Add OneSignal plugin
   this.addPlugin({

--- a/lib/module.js
+++ b/lib/module.js
@@ -71,11 +71,15 @@ function addOneSignal (oneSignalOptions) {
     })
   }
 
-  // Adjust manifest for oneSignal
-  if (!this.options.manifest) {
-    this.options.manifest = {}
+  if (!this.options.pwa) {
+    this.options.pwa = {}
   }
-  this.options.manifest.gcm_sender_id = options.GcmSenderId
+
+  // Adjust manifest for oneSignal
+  if (!this.options.pwa.manifest) {
+    this.options.pwa.manifest = {}
+  }
+  this.options.pwa.manifest.gcm_sender_id = options.GcmSenderId
 
   // Adjust swURL option of Workbox for oneSignal
   if (!this.options.pwa.workbox) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -78,8 +78,8 @@ function addOneSignal (oneSignalOptions) {
   this.options.manifest.gcm_sender_id = options.GcmSenderId
 
   // Adjust swURL option of Workbox for oneSignal
-  if (!this.options.workbox) {
-    this.options.workbox = {}
+  if (!this.options.pwa.workbox) {
+    this.options.pwa.workbox = {}
   }
   this.options.pwa.workbox.swURL = 'OneSignalSDKWorker.js'
 


### PR DESCRIPTION
- Workbox options should be under pwa.
- Both scripts (OneSignalSDKWorker.js and OneSignalSDKUpdaterWorker.js) should be modified to import sw.js in accordance with OneSignal documentation [https://documentation.onesignal.com/docs/onesignal-service-worker-faq#integrating-multiple-service-workers](url)

Fixes #1 